### PR TITLE
[FLINK-18748][Runtime/Checkpointing] trigger unperiodic checkpoint immediately

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
@@ -119,13 +119,13 @@ public class CheckpointRequestDeciderTest {
 	public void testSavepointTiming() {
 		testTiming(regularSavepoint(), TriggerExpectation.IMMEDIATELY);
 		testTiming(periodicSavepoint(), TriggerExpectation.IMMEDIATELY);
-		testTiming(nonForcedSavepoint(), TriggerExpectation.AFTER_PAUSE);
+		testTiming(nonForcedSavepoint(), TriggerExpectation.IMMEDIATELY);
 	}
 
 	@Test
 	public void testCheckpointTiming() {
 		testTiming(regularCheckpoint(), TriggerExpectation.DROPPED);
-		testTiming(manualCheckpoint(), TriggerExpectation.AFTER_PAUSE);
+		testTiming(manualCheckpoint(), TriggerExpectation.IMMEDIATELY);
 	}
 
 	private enum TriggerExpectation {IMMEDIATELY, AFTER_PAUSE, DROPPED}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request makes checkpoint/savepoint  triggered  immediately if it's not periodic*


## Brief change log

  - *Trigger checkpoint/savepoint immediately if it's not periodic*

## Verifying this change

This change is already covered by existing tests, such as *flink/runtime/checkpoint/CheckpointRequestDeciderTest:testSavepointTiming: nonForcedSavepoint && manualCheckpoint*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
